### PR TITLE
chore: add skeleton neko core package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ voices
 deps
 .venv
 .claude
+**/__pycache__/

--- a/src/capture.py
+++ b/src/capture.py
@@ -68,7 +68,6 @@ import shutil
 import signal
 import zipfile
 import logging
-import pathlib
 import tempfile
 import threading
 from dataclasses import dataclass, field
@@ -77,6 +76,9 @@ from typing import Any, Dict, Optional, List, Tuple
 # third-party (available in flake.nix shells)
 import requests
 import websockets
+
+from neko.logging import setup_logging
+from neko.utils import env_bool, now_iso, safe_mkdir
 
 try:
     # MosaicML Streaming
@@ -93,21 +95,6 @@ except Exception as e:
 # -----------------------
 # Configuration / Env
 # -----------------------
-def env_bool(name: str, default: bool) -> bool:
-    """Parse environment variable as boolean.
-    
-    Converts environment variable values to boolean, supporting both numeric
-    (0/1) and string representations (true/false, yes/no, on/off).
-    
-    :param name: Environment variable name to read
-    :param default: Default value if environment variable is not set
-    :return: Boolean value parsed from environment variable or default
-    """
-    val = os.environ.get(name, str(int(default)))
-    try:
-        return bool(int(val))
-    except Exception:
-        return str(val).lower() in {"true","t","yes","y","on"}
 
 NEKO_URL            = os.environ.get("NEKO_URL", "")
 NEKO_USER           = os.environ.get("NEKO_USER", "")
@@ -131,32 +118,11 @@ LOGLEVEL            = os.environ.get("CAPTURE_LOGLEVEL", "INFO").upper()
 # -----------------------
 # Logging
 # -----------------------
-logging.basicConfig(
-    level=LOGLEVEL,
-    format="[%(asctime)s] %(levelname)-7s %(message)s",
-    datefmt="%H:%M:%S",
-)
-log = logging.getLogger("capture")
+log = setup_logging(LOGLEVEL, name="capture")
 
 # -----------------------
 # Helpers / Types
 # -----------------------
-def now_iso() -> str:
-    """Return current UTC time in ISO 8601 format.
-    
-    :return: Current UTC timestamp as ISO 8601 string (YYYY-MM-DDTHH:MM:SS)
-    """
-    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
-
-def safe_mkdir(p: str) -> None:
-    """Create directory and any missing parent directories.
-    
-    Safe directory creation that won't fail if the directory already exists
-    and will create any missing parent directories in the path.
-    
-    :param p: Directory path to create
-    """
-    pathlib.Path(p).mkdir(parents=True, exist_ok=True)
 
 @dataclass
 class EpisodeBuffer:

--- a/src/manual.py
+++ b/src/manual.py
@@ -40,6 +40,7 @@ from typing import Dict, Any, Tuple, Optional, Set
 
 import requests
 import websockets
+from neko.logging import setup_logging
 
 # aiortc for SDP/ICE handshake (no media consumption)
 from aiortc import (
@@ -54,24 +55,12 @@ from aiortc.sdp import candidate_from_sdp
 # ---
 # Configure Logging
 # ---
-log_file = os.environ.get("NEKO_LOGFILE")
-if log_file:
-    logging.basicConfig(
-        level=os.environ.get("NEKO_LOGLEVEL", "INFO"),
-        format='[%(asctime)s] %(name)-12s %(levelname)-7s - %(message)s',
-        datefmt='%H:%M:%S',
-        filename=log_file,
-        filemode='a'
-    )
-else:
-    logging.basicConfig(
-        level=os.environ.get("NEKO_LOGLEVEL", "INFO"),
-        format='[%(asctime)s] %(name)-12s %(levelname)-7s - %(message)s',
-        datefmt='%H:%M:%S'
-    )
-logging.getLogger("websockets").setLevel(logging.WARNING)
-logging.getLogger("aiortc").setLevel(logging.WARNING)
-logger = logging.getLogger("neko_manual")
+logger = setup_logging(
+    os.environ.get("NEKO_LOGLEVEL", "INFO"),
+    os.environ.get("NEKO_LOG_FORMAT", "text"),
+    os.environ.get("NEKO_LOGFILE"),
+    name="neko_manual",
+)
 
 
 # ---

--- a/src/neko/__init__.py
+++ b/src/neko/__init__.py
@@ -1,0 +1,15 @@
+"""Neko core package.
+
+This package hosts reusable components shared across the various
+command line tools in ``src``.  The modules currently provide only
+lightweight placeholders so that future refactors can import from a
+consistent location.
+"""
+
+__all__ = [
+    "config",
+    "logging",
+    "websocket",
+    "webrtc",
+    "utils",
+]

--- a/src/neko/config.py
+++ b/src/neko/config.py
@@ -1,0 +1,37 @@
+"""Environment driven configuration helpers.
+
+The goal of this module is to centralize environment variable parsing
+for the different entrypoint scripts.  Only a small subset of settings
+are represented for now; additional fields can be added as the
+monolithic scripts are refactored.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+
+
+@dataclass
+class Settings:
+    """Basic runtime settings for the Neko tools."""
+
+    neko_ws: Optional[str] = None
+    log_level: str = "INFO"
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Construct settings from environment variables.
+
+        Only a limited subset of the eventual configuration surface is
+        implemented so that existing scripts can progressively migrate to
+        this module.
+        """
+
+        return cls(
+            neko_ws=os.getenv("NEKO_WS"),
+            log_level=os.getenv("NEKO_LOGLEVEL", "INFO"),
+        )
+
+
+__all__ = ["Settings"]

--- a/src/neko/logging.py
+++ b/src/neko/logging.py
@@ -1,0 +1,81 @@
+"""Logging configuration helpers.
+
+This module provides a :func:`setup_logging` function mirroring the common
+configuration used across the command line tools.  It supports both text and
+JSON output formats and silences noisy third‑party loggers.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+
+class _JsonFormatter(logging.Formatter):
+    """Simple JSON log formatter."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        data = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if record.exc_info:
+            data["exc"] = self.formatException(record.exc_info)
+        return json.dumps(data, ensure_ascii=False)
+
+
+def setup_logging(
+    level: str = "INFO",
+    fmt: str = "text",
+    log_file: Optional[str] = None,
+    name: Optional[str] = None,
+) -> logging.Logger:
+    """Configure and return a logger.
+
+    Parameters
+    ----------
+    level:
+        Logging level name, e.g. ``"INFO"`` or ``"DEBUG"``.
+    fmt:
+        ``"text"`` or ``"json"`` output format.
+    log_file:
+        Optional path to a log file.  If ``None`` only stdout is used.
+    name:
+        Logger name to return.  If omitted the root logger is returned.
+    """
+
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+    formatter: logging.Formatter
+    if fmt.lower() == "json":
+        formatter = _JsonFormatter()
+    else:  # pragma: no cover - formatter is trivial
+        formatter = logging.Formatter(
+            "[%(asctime)s] %(name)s %(levelname)s - %(message)s", "%H:%M:%S"
+        )
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    # Quiet noisy dependencies
+    logging.getLogger("websockets").setLevel(logging.WARNING)
+    logging.getLogger("aiortc").setLevel(logging.WARNING)
+    logging.getLogger("aioice").setLevel(logging.WARNING)
+    logging.getLogger("asyncio").setLevel(logging.ERROR)
+
+    return logging.getLogger(name) if name else root
+
+
+__all__ = ["setup_logging"]

--- a/src/neko/utils.py
+++ b/src/neko/utils.py
@@ -1,0 +1,38 @@
+"""Miscellaneous small utilities shared across scripts."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import os
+
+
+def now_iso() -> str:
+    """Return the current UTC time in ISO-8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def safe_mkdir(path: str | Path) -> Path:
+    """Create a directory if it does not exist and return its path."""
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def env_bool(name: str, default: bool) -> bool:
+    """Parse an environment variable as a boolean.
+
+    Values like ``1``, ``true``, ``yes`` and ``on`` are treated as ``True`` while
+    ``0``/``false``/``no``/``off`` map to ``False``.  If the variable is not set
+    the ``default`` value is returned.
+    """
+
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return bool(int(val))
+    except ValueError:
+        return val.strip().lower() in {"true", "t", "yes", "y", "on"}
+
+
+__all__ = ["now_iso", "safe_mkdir", "env_bool"]

--- a/src/neko/webrtc.py
+++ b/src/neko/webrtc.py
@@ -1,0 +1,29 @@
+"""Helpers for aiortc based WebRTC connections.
+
+Only a very small surface is provided to avoid copy/paste between
+scripts.  The goal is to gradually move the detailed logic out of the
+entrypoints and into reusable helpers.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
+
+
+def build_configuration(stun_url: str, turn_url: Optional[str] = None,
+                        turn_user: Optional[str] = None,
+                        turn_pass: Optional[str] = None) -> RTCConfiguration:
+    """Create an :class:`RTCConfiguration` with optional TURN support."""
+    ice_servers: Iterable[RTCIceServer] = [RTCIceServer(stun_url)]
+    if turn_url:
+        ice_servers.append(RTCIceServer(turn_url, turn_user, turn_pass))
+    return RTCConfiguration(iceServers=list(ice_servers))
+
+
+def create_peer_connection(config: RTCConfiguration) -> RTCPeerConnection:
+    """Return a new :class:`RTCPeerConnection` using ``config``."""
+    return RTCPeerConnection(configuration=config)
+
+
+__all__ = ["build_configuration", "create_peer_connection"]

--- a/src/neko/websocket.py
+++ b/src/neko/websocket.py
@@ -1,0 +1,46 @@
+"""Asynchronous WebSocket client utilities.
+
+The implementation here is intentionally lightweight.  It exposes a
+:class:`NekoWebSocketClient` class that follows the connection pattern used
+throughout the existing scripts.  Future work can expand it with
+reconnection logic and message routing.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+import websockets
+
+
+@dataclass
+class NekoWebSocketClient:
+    """Minimal wrapper around :mod:`websockets` for the Neko API."""
+
+    uri: str
+    token: Optional[str] = None
+
+    async def connect(self) -> websockets.WebSocketClientProtocol:
+        """Open the WebSocket connection."""
+        headers = {}
+        if self.token is not None:
+            headers["Authorization"] = f"Bearer {self.token}"
+        self._ws = await websockets.connect(self.uri, extra_headers=headers)
+        return self._ws
+
+    async def send(self, message: str) -> None:
+        """Send a text message to the server."""
+        await self._ws.send(message)
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        """Yield incoming messages from the server."""
+        async for msg in self._ws:
+            yield msg
+
+    async def close(self) -> None:
+        """Close the WebSocket connection."""
+        await self._ws.close()
+
+
+__all__ = ["NekoWebSocketClient"]

--- a/src/train.py
+++ b/src/train.py
@@ -79,52 +79,7 @@ import contextlib
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
-
-# --- Logging utilities (no heavy imports here) ---------------------------------
-
-class JsonFormatter(logging.Formatter):
-    """Format log records as JSON.
-
-    :param record: Log record instance
-    :returns: JSON string
-    """
-
-    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
-        data = {
-            "ts": self.formatTime(record, self.datefmt),
-            "level": record.levelname,
-            "logger": record.name,
-            "msg": record.getMessage(),
-        }
-        if record.exc_info:
-            data["exc"] = self.formatException(record.exc_info)
-        return json.dumps(data, ensure_ascii=False)
-
-
-def setup_logging(level: str = "INFO", fmt: str = "text") -> logging.Logger:
-    """Configure root logger with text or JSON formatting.
-
-    :param level: Log level name
-    :param fmt: 'text' or 'json'
-    :returns: Module logger
-    """
-    root = logging.getLogger()
-    for h in list(root.handlers):
-        root.removeHandler(h)
-    if fmt.lower() == "json":
-        formatter = JsonFormatter()
-    else:
-        formatter = logging.Formatter(
-            "[%(asctime)s] %(name)-12s %(levelname)-7s - %(message)s",
-            datefmt="%H:%M:%S",
-        )
-    h = logging.StreamHandler()
-    h.setFormatter(formatter)
-    root.addHandler(h)
-    root.setLevel(level.upper())
-    logging.getLogger("websockets").setLevel(logging.WARNING)
-    logging.getLogger("aiortc").setLevel(logging.WARNING)
-    return logging.getLogger("train")
+from neko.logging import setup_logging
 
 
 # --- Config --------------------------------------------------------------------
@@ -505,7 +460,7 @@ async def main(argv: Optional[Sequence[str]] = None) -> None:
             else:
                 setattr(cfg, k if k not in ("local", "remote", "cache", "output") else k, v)
 
-    log = setup_logging(cfg.loglevel, cfg.log_format)
+    log = setup_logging(cfg.loglevel, cfg.log_format, name="train")
     errs = cfg.validate()
     if errs:
         for e in errs:


### PR DESCRIPTION
## Summary
- establish initial `neko` package with config, logging, websocket, webrtc, and utility helpers
- ignore `__pycache__` directories across the repo
- centralize logging and environment helpers in `neko` package and adopt them across scripts

## Testing
- `python -m py_compile $(find src -name '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aacb7e9ae883318f6ace5b7679736e