### PR TITLE
docs: align configuration defaults with code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,14 +80,14 @@ NEKO_TASK="Search the weather"         # Default task if not passed via CLI
 NEKO_MODE="web"                        # "web" or "phone"
 NEKO_MAX_STEPS=8                       # Max navigation steps
 NEKO_AUDIO=1                           # 1 to enable audio, 0 to disable
-REFINEMENT_STEPS=1                     # Coordinate refinement passes
-NEKO_ICE_POLICY="all"                  # ICE policy hint for your stack
+REFINEMENT_STEPS=5                     # Coordinate refinement passes
+NEKO_ICE_POLICY="strict"               # ICE policy hint for your stack ("strict" or "all")
 # NEKO_RUN_ID="dev-run-abc123"         # Optional run identifier
+NEKO_RTCP_KEEPALIVE=0                  # 1 to send RTCP keepalives for long-lived TURN/NAT sessions
 
 ########################################
 # Model Config
 ########################################
-MODEL_KEY="showui-2b"
 REPO_ID="showlab/ShowUI-2B"
 SIZE_SHORTEST_EDGE=224
 SIZE_LONGEST_EDGE=1344

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ mdbook serve --open
 Or use the convenience command from the project root:
 
 ```bash
-just docs-serve  # (if available)
+nix run .#docs-serve
 ```
 
 ## GitHub Pages Deployment

--- a/docs/src/developer-guide/architecture.md
+++ b/docs/src/developer-guide/architecture.md
@@ -253,13 +253,13 @@ neko-services up
 
 # Terminal 2: Agent
 nix develop .#gpu  
-python src/agent.py --task "automation task"
+uv run src/agent.py --task "automation task"
 
 # Terminal 3: Capture (optional)
-python src/capture.py
+uv run src/capture.py
 
 # Terminal 4: TTS (optional)
-python src/yap.py
+uv run src/yap.py
 ```
 
 ### Production Considerations

--- a/docs/src/developer-guide/components/agent.md
+++ b/docs/src/developer-guide/components/agent.md
@@ -629,7 +629,7 @@ agent = NekoAgent(
 
 ```bash
 # Validate configuration
-python src/agent.py --healthcheck
+uv run src/agent.py --healthcheck
 
 # Expected output:
 # Configuration validation: PASSED
@@ -646,7 +646,7 @@ export NEKO_LOGLEVEL="DEBUG"
 export FRAME_SAVE_PATH="./debug/frames"
 export CLICK_SAVE_PATH="./debug/actions"
 
-python src/agent.py --task "test navigation" --max-steps 3
+uv run src/agent.py --task "test navigation" --max-steps 3
 ```
 
 ### Frame Analysis
@@ -675,10 +675,10 @@ export CAPTURE_OUT="./training-data"
 export CAPTURE_REMOTE="s3://training-bucket/episodes"
 
 # Start capture in background
-python src/capture.py &
+uv run src/capture.py &
 
 # Run agent (capture will automatically record)
-python src/agent.py --task "automation task"
+uv run src/agent.py --task "automation task"
 ```
 
 ### With TTS Service
@@ -688,10 +688,10 @@ python src/agent.py --task "automation task"
 export YAP_VOICES_DIR="./voices"
 
 # Start TTS service
-python src/yap.py &
+uv run src/yap.py &
 
-# Run agent with voice enabled
-python src/agent.py --task "automation task" --audio
+# Run agent with voice enabled (audio is negotiated automatically)
+uv run src/agent.py --task "automation task"
 ```
 
 ## Future Enhancements

--- a/docs/src/developer-guide/nix-flake.md
+++ b/docs/src/developer-guide/nix-flake.md
@@ -753,7 +753,7 @@ print('Model loaded successfully')
 "
 
 # 4. Run agent
-python src/agent.py --task "Navigate to google.com"
+uv run src/agent.py --task "Navigate to google.com"
 ```
 
 ### Documentation Development

--- a/docs/src/user-guide/agent.md
+++ b/docs/src/user-guide/agent.md
@@ -15,13 +15,13 @@ The agent uses the ShowUI-2B vision-language model to:
 ### Basic Command
 
 ```bash
-python src/agent.py --task "Search for weather in Tokyo"
+uv run src/agent.py --task "Search for weather in Tokyo"
 ```
 
 ### With Neko Server Connection
 
 ```bash
-python src/agent.py \
+uv run src/agent.py \
   --task "Navigate to GitHub and search for Python projects" \
   --neko-url "http://localhost:8080" \
   --username "user" \
@@ -31,7 +31,7 @@ python src/agent.py \
 ### Keep Agent Running (Online Mode)
 
 ```bash
-python src/agent.py \
+uv run src/agent.py \
   --task "Check email" \
   --online
 ```
@@ -59,16 +59,16 @@ python src/agent.py \
 |--------|---------------------|---------|-------------|
 | `--mode` | `NEKO_MODE` | `web` | Interface mode: `web` or `phone` |
 | `--max-steps` | `NEKO_MAX_STEPS` | `8` | Maximum automation steps before stopping |
-| `--online` | `NEKO_ONLINE` | `false` | Keep running after task completion |
-| `--no-audio` | `NEKO_AUDIO` | `true` | Disable audio stream from Neko |
+| `--online` | – | `false` | Keep running after task completion; ignores the initial task |
+| `--no-audio` | `NEKO_AUDIO=0` | `1` | Disable audio negotiation with the Neko server |
 
 ### Technical Options
 
 | Option | Environment Variable | Default | Description |
 |--------|---------------------|---------|-------------|
 | `--metrics-port` | `NEKO_METRICS_PORT`/`PORT` | `9000` | Prometheus metrics server port |
-| `--loglevel` | `NEKO_LOGLEVEL` | `INFO` | Logging level (DEBUG, INFO, WARN, ERROR) |
-| `--healthcheck` | - | - | Validate configuration and exit |
+| `--loglevel` | `NEKO_LOGLEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
+| `--healthcheck` | – | – | Validate configuration and exit |
 
 ## Usage Patterns
 
@@ -77,7 +77,7 @@ python src/agent.py \
 Run one task and exit when complete:
 
 ```bash
-python src/agent.py --task "Book a flight from NYC to LAX"
+uv run src/agent.py --task "Book a flight from NYC to LAX"
 ```
 
 ### Continuous Operation
@@ -85,7 +85,7 @@ python src/agent.py --task "Book a flight from NYC to LAX"
 Stay online to handle multiple tasks via chat interface:
 
 ```bash
-python src/agent.py --task "Ready for commands" --online
+uv run src/agent.py --task "Ready for commands" --online
 ```
 
 In online mode, send new tasks through the Neko chat interface.
@@ -95,7 +95,7 @@ In online mode, send new tasks through the Neko chat interface.
 Switch to mobile interface mode:
 
 ```bash
-python src/agent.py \
+uv run src/agent.py \
   --mode phone \
   --task "Open Instagram and check notifications"
 ```
@@ -105,7 +105,7 @@ python src/agent.py \
 Skip REST login with direct WebSocket URL:
 
 ```bash
-python src/agent.py \
+uv run src/agent.py \
   --ws "wss://neko.example.com/api/ws?token=your-token" \
   --task "Your automation task"
 ```
@@ -115,11 +115,10 @@ python src/agent.py \
 ### Core Settings
 
 ```bash
-# Task and behavior
+# Task and behaviour
 export NEKO_TASK="Default task description"
 export NEKO_MODE="web"  # or "phone"
-export NEKO_MAX_STEPS="15"
-export NEKO_ONLINE="false"
+export NEKO_MAX_STEPS="8"
 
 # Connection
 export NEKO_URL="http://localhost:8080"
@@ -128,27 +127,38 @@ export NEKO_PASS="password"
 export NEKO_WS="wss://direct.websocket.url/api/ws?token=..."
 
 # Technical
+export NEKO_AUDIO="1"
 export NEKO_LOGLEVEL="INFO"
+export NEKO_LOG_FORMAT="text"
 export NEKO_METRICS_PORT="9000"
-export NEKO_AUDIO="true"
+export NEKO_RTCP_KEEPALIVE="0"
+export NEKO_FORCE_EXIT_GUARD_MS="0"
+export NEKO_SKIP_INITIAL_FRAMES="5"
+# FRAME_SAVE_PATH="./tmp/frame.png"
+# CLICK_SAVE_PATH="./tmp/actions"
 ```
 
 ### Advanced Configuration
 
 ```bash
 # Model settings
-export NEKO_REPO_ID="Qwen/Qwen2-VL-2B-Instruct"
-export NEKO_SIZE_SHORTEST_EDGE="768"
-export NEKO_SIZE_LONGEST_EDGE="1280"
+export REPO_ID="showlab/ShowUI-2B"
+export SIZE_SHORTEST_EDGE="224"
+export SIZE_LONGEST_EDGE="1344"
+export OFFLOAD_FOLDER="./offload"  # used for MPS offloading
 
 # Network tuning
-export NEKO_WS_TIMEOUT="30"
-export NEKO_ICE_TIMEOUT="10"
+export NEKO_ICE_POLICY="strict"       # or "all" for permissive ICE gathering
+export NEKO_STUN_URL="stun:stun.l.google.com:19302"
+# export NEKO_TURN_URL="turn:turn.example.com:3478"
+# export NEKO_TURN_USER="..."
+# export NEKO_TURN_PASS="..."
 export NEKO_RTCP_KEEPALIVE="1"
 
 # Performance
+export REFINEMENT_STEPS="5"
 export NEKO_FORCE_EXIT_GUARD_MS="5000"
-export NEKO_LOG_FORMAT="json"  # or "text"
+export NEKO_LOG_FORMAT="json"        # or "text"
 ```
 
 ## Task Examples
@@ -157,33 +167,33 @@ export NEKO_LOG_FORMAT="json"  # or "text"
 
 ```bash
 # E-commerce
-python src/agent.py --task "Add wireless headphones to Amazon cart"
+uv run src/agent.py --task "Add wireless headphones to Amazon cart"
 
 # Information gathering
-python src/agent.py --task "Find the latest news about AI developments"
+uv run src/agent.py --task "Find the latest news about AI developments"
 
 # Form filling
-python src/agent.py --task "Fill out the contact form with test data"
+uv run src/agent.py --task "Fill out the contact form with test data"
 ```
 
 ### Social Media
 
 ```bash
 # Content creation
-python src/agent.py --task "Post a tweet about climate change"
+uv run src/agent.py --task "Post a tweet about climate change"
 
 # Engagement
-python src/agent.py --task "Like the latest 5 posts from my Twitter timeline"
+uv run src/agent.py --task "Like the latest 5 posts from my Twitter timeline"
 ```
 
 ### Productivity
 
 ```bash
 # Email management
-python src/agent.py --task "Check unread emails and summarize important ones"
+uv run src/agent.py --task "Check unread emails and summarize important ones"
 
 # Calendar scheduling
-python src/agent.py --task "Schedule a meeting for next Tuesday at 2pm"
+uv run src/agent.py --task "Schedule a meeting for next Tuesday at 2pm"
 ```
 
 ## Monitoring and Debugging
@@ -193,7 +203,7 @@ python src/agent.py --task "Schedule a meeting for next Tuesday at 2pm"
 Validate configuration without running tasks:
 
 ```bash
-python src/agent.py --healthcheck
+uv run src/agent.py --healthcheck
 ```
 
 ### Metrics
@@ -205,22 +215,25 @@ curl http://localhost:9000/metrics
 ```
 
 Key metrics:
-- `neko_agent_tasks_total` - Total tasks processed
-- `neko_agent_steps_total` - Total automation steps taken
-- `neko_agent_errors_total` - Total errors encountered
-- `neko_agent_inference_duration_seconds` - AI model inference time
+- `neko_frames_received_total` - Total video frames processed
+- `neko_actions_executed_total{action_type="..."}` - Actions emitted, labelled by type
+- `neko_parse_errors_total` - Count of action parsing failures
+- `neko_navigation_steps_total` - Steps taken while executing tasks
+- `neko_inference_latency_seconds` - Model inference latency histogram
+- `neko_resize_duration_seconds` - Time spent handling resize events
+- `neko_reconnects_total` - WebSocket reconnection attempts
 
 ### Debug Logging
 
 Enable detailed logging:
 
 ```bash
-python src/agent.py --loglevel DEBUG --task "Your task"
+uv run src/agent.py --loglevel DEBUG --task "Your task"
 ```
 
 ### Frame Capture
 
-Screenshots and interaction data are saved to `/tmp/neko-agent/` during execution for debugging.
+Set `FRAME_SAVE_PATH` or `CLICK_SAVE_PATH` to persist artefacts. Relative paths are resolved under `/tmp/neko-agent/`.
 
 ## Integration with Other Services
 
@@ -230,10 +243,10 @@ Run alongside capture service to collect training data:
 
 ```bash
 # Terminal 1: Start capture
-python src/capture.py
+uv run src/capture.py
 
 # Terminal 2: Run agent
-python src/agent.py --task "Navigate and interact for training"
+uv run src/agent.py --task "Navigate and interact for training"
 ```
 
 ### Voice Synthesis
@@ -242,10 +255,10 @@ Add voice feedback during automation:
 
 ```bash
 # Terminal 1: Start TTS service
-python src/yap.py
+uv run src/yap.py
 
 # Terminal 2: Run agent with voice
-python src/agent.py --task "Describe actions as you perform them"
+uv run src/agent.py --task "Describe actions as you perform them"
 ```
 
 ## Troubleshooting
@@ -258,13 +271,13 @@ python src/agent.py --task "Describe actions as you perform them"
 curl http://localhost:8080/health
 
 # Verify WebSocket endpoint
-python src/agent.py --healthcheck
+uv run src/agent.py --healthcheck
 ```
 
 **Authentication errors:**
 ```bash
 # Test REST login manually
-curl -X POST http://localhost:8080/auth/login \
+curl -X POST http://localhost:8080/api/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user","password":"pass"}'
 ```
@@ -309,10 +322,10 @@ Write clear, specific task descriptions:
 
 ```bash
 # Good
-python src/agent.py --task "Navigate to reddit.com, search for 'python tutorials', and save the first 3 post titles"
+uv run src/agent.py --task "Navigate to reddit.com, search for 'python tutorials', and save the first 3 post titles"
 
 # Avoid vague descriptions
-python src/agent.py --task "do some web stuff"
+uv run src/agent.py --task "do some web stuff"
 ```
 
 ### Resource Management

--- a/docs/src/user-guide/manual-control.md
+++ b/docs/src/user-guide/manual-control.md
@@ -10,17 +10,12 @@ The Manual Control CLI is an interactive tool that lets you remotely control any
 - Access to a Neko server (either local or hosted)
 - Network connectivity to the Neko server
 
-### Installation
+### Launching the CLI
 
-The manual control tool is included with the Neko Agent package:
+The manual control tool ships as `src/manual.py` inside this repository. From a Nix shell you can run:
 
 ```bash
-# If you have the project locally
-cd /path/to/neko_agent_private
-python src/manual.py --help
-
-# Or if installed as a package
-neko-manual --help
+uv run src/manual.py --help
 ```
 
 ### First Connection
@@ -28,7 +23,7 @@ neko-manual --help
 The easiest way to connect is using your Neko server credentials:
 
 ```bash
-python src/manual.py \
+uv run src/manual.py \
   --neko-url "https://your-neko-server.com" \
   --username "your-username" \
   --password "your-password"
@@ -97,13 +92,24 @@ neko> scroll left 2
 neko> swipe 100 100 300 300
 ```
 
-### Coordinate Systems
+### CLI switches
 
-By default, the tool uses pixel coordinates based on your screen resolution. You can also use normalized coordinates (0.0 to 1.0) for resolution-independent control:
+`manual.py` mirrors the agent’s authentication behaviour: provide either a full WebSocket URL (`--ws`) or REST credentials (`--neko-url`, `--username`, `--password`). Additional flags include:
+
+| Flag | Purpose |
+|------|---------|
+| `--norm` | Interpret coordinates as 0.0–1.0 floats instead of pixels |
+| `--size 1920x1080` | Override the reported screen size when using pixel coordinates |
+| `--no-auto-host` | Do not automatically request host control on connect |
+| `--no-media` | Skip WebRTC negotiation (only for debugging signalling) |
+| `--no-audio` | Disable audio subscription |
+
+By default the CLI learns the keyboard layout advertised by the server and stores logs under `NEKO_LOGFILE` if that environment variable is set.
+
+#### Normalised coordinates example
 
 ```bash
-# Start with normalized coordinates
-python src/manual.py --norm \
+uv run src/manual.py --norm \
   --neko-url "https://your-server.com" \
   --username "admin" --password "secret"
 
@@ -260,14 +266,15 @@ export NEKO_PASS="your-password"
 export NEKO_SIZE="1920x1080"
 
 # Now you can just run:
-python src/manual.py
+uv run src/manual.py
 ```
 
 ### Command Line Options
 
 | Option | Description | Example |
 |--------|-------------|---------|
-| `--neko-url` | Neko server URL | `https://neko.example.com` |
+| `--ws` | Direct WebSocket URL | `wss://neko.example.com/api/ws?token=...` |
+| `--neko-url` | Neko server URL (for REST login) | `https://neko.example.com` |
 | `--username` | Login username | `admin` |
 | `--password` | Login password | `secretpass` |
 | `--norm` | Use 0-1 coordinates | (flag only) |
@@ -283,7 +290,7 @@ Enable detailed logging for troubleshooting:
 ```bash
 export NEKO_LOGLEVEL="DEBUG"
 export NEKO_LOGFILE="/tmp/neko-manual.log"
-python src/manual.py --neko-url "..." --username "..." --password "..."
+uv run src/manual.py --neko-url "..." --username "..." --password "..."
 
 # In another terminal, watch the logs:
 tail -f /tmp/neko-manual.log
@@ -297,7 +304,7 @@ For automation scripts, you may need to add delays between actions:
 
 ```bash
 # The tool doesn't have built-in delays, but you can use shell scripting:
-echo -e "tap 300 200\ntext hello\nkey Enter" | python src/manual.py --neko-url "..." --username "..." --password "..."
+echo -e "tap 300 200\ntext hello\nkey Enter" | uv run src/manual.py --neko-url "..." --username "..." --password "..."
 ```
 
 ### Screen Resolution
@@ -351,7 +358,7 @@ export NEKO_PASS="password"
     echo "key Tab"                      # Next field
     echo "text testpass"                # Password  
     echo "key Enter"                    # Submit
-} | python src/manual.py
+} | uv run src/manual.py
 ```
 
 ## Troubleshooting

--- a/docs/src/user-guide/yap.md
+++ b/docs/src/user-guide/yap.md
@@ -29,7 +29,7 @@ export NEKO_URL="http://localhost:8080"
 export NEKO_USER="user" 
 export NEKO_PASS="password"
 
-python src/yap.py
+uv run src/yap.py
 ```
 
 You should see:
@@ -238,10 +238,10 @@ Start YAP alongside your automation agent:
 
 ```bash
 # Terminal 1: Start YAP
-python src/yap.py
+uv run src/yap.py
 
-# Terminal 2: Run automation with voice
-python src/agent.py --task "Fill out contact form" --enable-voice
+# Terminal 2: Run automation with voice (audio is enabled by default)
+uv run src/agent.py --task "Fill out contact form"
 ```
 
 The agent can announce progress:
@@ -257,7 +257,7 @@ Use YAP for live interaction during manual control:
 
 ```bash
 # Terminal 1: Start YAP
-python src/yap.py
+uv run src/yap.py
 
 # Terminal 2: Manual control
 python src/manual.py
@@ -305,7 +305,7 @@ Set up different voices for different purposes:
 
 **Test connection:**
 ```bash
-python src/yap.py --healthcheck
+uv run src/yap.py --healthcheck
 ```
 
 ### Poor Audio Quality
@@ -374,7 +374,7 @@ Enable detailed logging:
 ```bash
 export YAP_LOGLEVEL=DEBUG
 export YAP_LOG_FORMAT=json
-python src/yap.py 2>&1 | jq .
+uv run src/yap.py 2>&1 | jq .
 ```
 
 Look for:


### PR DESCRIPTION
## Summary
- update the sample configuration in `.env.example`, the README, and user guides to reflect the agent's actual defaults (NEKO_MAX_STEPS=8, REFINEMENT_STEPS=5, NEKO_ICE_POLICY=strict)
- document the NEKO_RTCP_KEEPALIVE toggle consistently across the environment examples and remove the unused MODEL_KEY entry

## Testing
- `mdbook build` *(fails: command not found: mdbook in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d228ff35b48331addb4e8dacd525ab