### PR TITLE
Improve agent refinement and capture hooks

### DIFF
--- a/src/capture_refactored.py
+++ b/src/capture_refactored.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# src/capture_refactored.py
 """
 capture_refactored.py — Training-data capture client using HTTPNekoClient.
 
@@ -10,10 +8,13 @@ What this does
 - Pulls frames via HTTP screenshot endpoint at a fixed FPS
 - Packages episodes as MDS shards for training
 
-Refactored from original capture.py to use modular neko_comms library.
+Refactored from original capture.py to use modular neko_comms library while
+retaining the legacy capture functionality.
 """
 
 import asyncio
+import contextlib
+import io
 import json
 import logging
 import os
@@ -24,23 +25,21 @@ import threading
 import time
 import uuid
 import zipfile
-from pathlib import Path
-from typing import Dict, List, Optional, Any
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 from streaming import MDSWriter
-from PIL import Image
 
 from neko_comms import HTTPNekoClient
 
-
-# Environment-based configuration
+# Environment-based configuration mirrors capture.py defaults
 CAPTURE_OUT = os.environ.get("CAPTURE_OUT", "./data/mds")
 CAPTURE_REMOTE = os.environ.get("CAPTURE_REMOTE", "")
-CAPTURE_KEEP_LOCAL = int(os.environ.get("CAPTURE_KEEP_LOCAL", "0"))
-CAPTURE_COMPRESSION = os.environ.get("CAPTURE_COMPRESSION", "zstd:6")
+CAPTURE_KEEP_LOCAL = bool(int(os.environ.get("CAPTURE_KEEP_LOCAL", "0")))
+CAPTURE_COMPRESSION = os.environ.get("CAPTURE_COMPRESSION", "zstd:6") or None
 CAPTURE_SHARD_SIZE = os.environ.get("CAPTURE_SHARD_SIZE", "512mb")
-CAPTURE_HASHES = os.environ.get("CAPTURE_HASHES", "sha1").split(",")
-CAPTURE_FPS = float(os.environ.get("CAPTURE_FPS", "2"))
+CAPTURE_HASHES = [h.strip() for h in os.environ.get("CAPTURE_HASHES", "sha1").split(",") if h.strip()]
+CAPTURE_FPS = float(os.environ.get("CAPTURE_FPS", "2.0"))
 CAPTURE_JPEG_QUALITY = int(os.environ.get("CAPTURE_JPEG_QUALITY", "85"))
 CAPTURE_MIN_FRAMES = int(os.environ.get("CAPTURE_MIN_FRAMES", "4"))
 CAPTURE_EP_TIMEOUT = int(os.environ.get("CAPTURE_EPISODE_TIMEOUT", "900"))
@@ -54,136 +53,158 @@ STOP_RE = re.compile(r"^/stop\s*$", re.IGNORECASE)
 ACTION_RE = re.compile(r"^Action:\s*(\{.*\})\s*$", re.DOTALL)
 
 
+# ----------------------
+# Helpers
+# ----------------------
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+
+
+def safe_mkdir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def make_mds_writer(
+    local_out: str,
+    remote_out: Optional[str],
+    keep_local: bool,
+    compression: Optional[str],
+    shard_size: str,
+    hashes: List[str],
+) -> MDSWriter:
+    columns = {
+        "episode_id": "str",
+        "task": "str",
+        "payload": "bytes",
+        "num_frames": "int",
+        "num_actions": "int",
+        "started_at": "str",
+        "ended_at": "str",
+        "screen_w": "int",
+        "screen_h": "int",
+        "agent": "json",
+    }
+
+    if remote_out:
+        out: Any = (local_out, remote_out)
+    else:
+        out = local_out
+
+    writer = MDSWriter(
+        columns=columns,
+        out=out,
+        keep_local=keep_local,
+        compression=compression,
+        hashes=hashes or None,
+        size_limit=shard_size,
+        progress_bar=True,
+        exist_ok=True,
+    )
+    return writer
+
+
+# ----------------------
+# Episode buffering (matches capture.py semantics)
+# ----------------------
+@dataclass
 class EpisodeBuffer:
-    """Buffer for collecting episode data (frames, actions, metadata)."""
+    root: str
+    episode_id: str
+    task_text: str
+    screen_size: tuple[int, int] = (0, 0)
+    started_at: str = field(default_factory=now_iso)
+    frames_dir: str = field(init=False)
+    actions_path: str = field(init=False)
+    frames_idx: int = field(default=0)
+    _closed: bool = field(default=False)
 
-    def __init__(self, root: str, episode_id: str, task_text: str, screen_size: tuple):
-        """Initialize episode buffer.
+    def __post_init__(self) -> None:
+        safe_mkdir(self.root)
+        self.frames_dir = os.path.join(self.root, "frames")
+        safe_mkdir(self.frames_dir)
+        self.actions_path = os.path.join(self.root, "actions.ndjson")
+        with open(self.actions_path, "wb") as fh:
+            fh.write(b"")
+        frames_index = os.path.join(self.root, "frames.ndjson")
+        with open(frames_index, "wb") as fh:
+            fh.write(b"")
 
-        :param root: Temporary directory for this episode
-        :param episode_id: Unique episode identifier
-        :param task_text: Task description
-        :param screen_size: Screen dimensions (width, height)
-        """
-        self.root = Path(root)
-        self.episode_id = episode_id
-        self.task_text = task_text
-        self.screen_size = screen_size
+    def add_frame(self, jpg_bytes: bytes, ts: float) -> None:
+        if self._closed:
+            return
+        name = f"{self.frames_idx:06d}.jpg"
+        frame_path = os.path.join(self.frames_dir, name)
+        with open(frame_path, "wb") as fh:
+            fh.write(jpg_bytes)
+        record = {"i": self.frames_idx, "ts": ts, "file": f"frames/{name}"}
+        frames_index = os.path.join(self.root, "frames.ndjson")
+        with open(frames_index, "ab") as fh:
+            fh.write((json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8"))
+        self.frames_idx += 1
 
-        # Create directory structure
-        self.frames_dir = self.root / "frames"
-        self.frames_dir.mkdir(parents=True, exist_ok=True)
+    def add_action(self, action: Dict[str, Any], ts: float, raw: Optional[str] = None) -> None:
+        if self._closed:
+            return
+        record = {"ts": ts, "action": action}
+        if raw:
+            record["raw"] = raw
+        with open(self.actions_path, "ab") as fh:
+            fh.write((json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8"))
 
-        # File paths
-        self.frames_ndjson = self.root / "frames.ndjson"
-        self.actions_ndjson = self.root / "actions.ndjson"
-        self.meta_json = self.root / "meta.json"
-
-        # Initialize files
-        self.frames_ndjson.touch()
-        self.actions_ndjson.touch()
-
-        # Frame counter
-        self.frame_count = 0
-
-    def add_frame(self, img: Image.Image, jpeg_quality: int = 85) -> None:
-        """Add a frame to the episode.
-
-        :param img: PIL Image to add
-        :param jpeg_quality: JPEG compression quality
-        """
-        frame_name = f"{self.frame_count:06d}.jpg"
-        frame_path = self.frames_dir / frame_name
-
-        # Save frame as JPEG
-        img.save(frame_path, "JPEG", quality=jpeg_quality)
-
-        # Add to frames.ndjson
-        frame_record = {
-            "frame_id": self.frame_count,
-            "filename": frame_name,
-            "timestamp": time.time(),
-            "width": img.width,
-            "height": img.height,
-        }
-
-        with open(self.frames_ndjson, "a") as f:
-            f.write(json.dumps(frame_record) + "\n")
-
-        self.frame_count += 1
-
-    def add_action(self, action_data: Dict[str, Any]) -> None:
-        """Add an action to the episode.
-
-        :param action_data: Action dictionary
-        """
-        action_record = {
-            "timestamp": time.time(),
-            "action": action_data,
-        }
-
-        with open(self.actions_ndjson, "a") as f:
-            f.write(json.dumps(action_record) + "\n")
-
-    def finalize_zip_bytes(self, agent_meta: Dict[str, Any]) -> bytes:
-        """Finalize episode and return as zip bytes.
-
-        :param agent_meta: Agent metadata
-        :return: Zip file contents as bytes
-        """
-        # Create meta.json
+    def finalize_zip_bytes(self, ended_at: Optional[str], agent_meta: Dict[str, Any]) -> bytes:
+        if self._closed:
+            return b""
+        self._closed = True
+        ended_at = ended_at or now_iso()
         meta = {
             "episode_id": self.episode_id,
             "task": self.task_text,
-            "screen_size": self.screen_size,
-            "frame_count": self.frame_count,
-            "created_at": time.time(),
-            **agent_meta,
+            "started_at": self.started_at,
+            "ended_at": ended_at,
+            "screen": {"width": self.screen_size[0], "height": self.screen_size[1]},
+            "num_frames": self.frames_idx,
+            "agent": agent_meta,
+            "schema": {
+                "frames": "frames/<NNNNNN>.jpg (JPEG, RGB)",
+                "frames_index": "frames.ndjson (one JSON object per line: {i, ts, file})",
+                "actions": "actions.ndjson (one JSON object per line: {ts, action, raw?})",
+            },
+            "tool": "capture_refactored.py",
+            "tool_version": "1.0",
         }
 
-        with open(self.meta_json, "w") as f:
-            json.dump(meta, f, indent=2)
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("meta.json", json.dumps(meta, ensure_ascii=False, indent=2))
+            frames_index = os.path.join(self.root, "frames.ndjson")
+            if os.path.exists(frames_index):
+                zf.write(frames_index, arcname="frames.ndjson")
+            if os.path.exists(self.actions_path):
+                zf.write(self.actions_path, arcname="actions.ndjson")
+            for name in sorted(os.listdir(self.frames_dir)):
+                path = os.path.join(self.frames_dir, name)
+                if os.path.isfile(path) and name.endswith(".jpg"):
+                    zf.write(path, arcname=f"frames/{name}")
 
-        # Create zip file in memory
-        import io
-        zip_buffer = io.BytesIO()
-
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-            # Add meta.json
-            zf.write(self.meta_json, "meta.json")
-
-            # Add frames.ndjson
-            zf.write(self.frames_ndjson, "frames.ndjson")
-
-            # Add actions.ndjson
-            zf.write(self.actions_ndjson, "actions.ndjson")
-
-            # Add all frame files
-            for frame_file in self.frames_dir.glob("*.jpg"):
-                zf.write(frame_file, f"frames/{frame_file.name}")
-
-        return zip_buffer.getvalue()
+        buffer.seek(0)
+        payload = buffer.read()
+        shutil.rmtree(self.root, ignore_errors=True)
+        return payload
 
 
+# ----------------------
+# Capture orchestrator
+# ----------------------
 class NekoCapture:
-    """Training data capture orchestrator using HTTPNekoClient."""
-
-    def __init__(self,
-                 neko_client: HTTPNekoClient,
-                 writer: MDSWriter,
-                 fps: float = CAPTURE_FPS,
-                 jpeg_quality: int = CAPTURE_JPEG_QUALITY,
-                 min_frames: int = CAPTURE_MIN_FRAMES,
-                 episode_timeout: int = CAPTURE_EP_TIMEOUT):
-        """Initialize capture orchestrator.
-
-        :param neko_client: HTTPNekoClient instance
-        :param writer: MDSWriter for writing training data
-        :param fps: Screenshot capture framerate
-        :param jpeg_quality: JPEG quality for screenshots
-        :param min_frames: Minimum frames required to save episode
-        :param episode_timeout: Timeout in seconds to auto-end episodes
-        """
+    def __init__(
+        self,
+        neko_client: HTTPNekoClient,
+        writer: MDSWriter,
+        fps: float = CAPTURE_FPS,
+        jpeg_quality: int = CAPTURE_JPEG_QUALITY,
+        min_frames: int = CAPTURE_MIN_FRAMES,
+        episode_timeout: int = CAPTURE_EP_TIMEOUT,
+    ) -> None:
         self.neko = neko_client
         self.writer = writer
         self.fps = fps
@@ -191,95 +212,74 @@ class NekoCapture:
         self.min_frames = min_frames
         self.episode_timeout = episode_timeout
 
-        # Episode state
         self._episode: Optional[EpisodeBuffer] = None
         self._episode_last_ts: float = 0.0
         self._poll_thread: Optional[threading.Thread] = None
         self._poll_stop_event: Optional[threading.Event] = None
-        self._agent_meta = {"source": "neko+capture_refactored", "notes": "refactored using neko_comms"}
-
-        # Stop event
         self._stop_event = threading.Event()
+        self._agent_meta = {"source": "neko+showui", "notes": "frames via shot.jpg; actions via chat"}
 
     async def run(self) -> None:
-        """Main capture loop."""
         log.info("Starting capture session")
-
-        # Connect to Neko server
         await self.neko.connect()
         self.neko.add_chat_listener(self._process_chat_message)
 
         try:
-            # Listen for chat messages
             await self._chat_listener()
         finally:
-            # Clean up
             await self._cleanup()
 
     async def _chat_listener(self) -> None:
-        """Listen for chat commands and action annotations."""
-        # Keep running until stopped
         while not self._stop_event.is_set():
             await asyncio.sleep(0.1)
-
-            # Check for episode timeout
-            if self._episode and time.time() - self._episode_last_ts > self.episode_timeout:
+            if self._episode and (time.time() - self._episode_last_ts > self.episode_timeout):
                 log.warning("Episode timeout - auto-ending")
                 self._end_episode("timeout")
 
-    def _process_chat_message(self, content: str, msg: Dict[str, Any]) -> None:
-        """Process chat messages for capture commands.
+    def _process_chat_message(self, _content: str, msg: Dict[str, Any]) -> None:
+        text = self._extract_text(msg)
+        if not text:
+            return
+        text = text.strip()
 
-        :param content: Message content
-        :param msg: Full message dictionary
-        """
-        content = content.strip()
-
-        # Check for /start command
-        if match := START_RE.match(content):
+        if match := START_RE.match(text):
             task_text = match.group(1)
             self._begin_episode(task_text)
             return
 
-        # Check for /stop command
-        if STOP_RE.match(content):
+        if STOP_RE.match(text):
             self._end_episode("stopped")
             return
 
-        # Check for action annotation
-        if match := ACTION_RE.match(content):
+        if match := ACTION_RE.match(text):
+            raw = match.group(1)
             try:
-                action_data = json.loads(match.group(1))
-                if self._episode:
-                    self._episode.add_action(action_data)
-                    self._episode_last_ts = time.time()
-                    log.debug("Recorded action: %s", action_data.get("action", "unknown"))
+                action_data = json.loads(raw)
             except json.JSONDecodeError:
-                log.warning("Failed to parse action: %s", match.group(1))
+                log.warning("Failed to parse action: %s", raw)
+                return
+            if self._episode:
+                ts = time.time()
+                self._episode.add_action(action_data, ts, raw)
+                self._episode_last_ts = ts
+                log.debug("Recorded action: %s", action_data.get("action", "unknown"))
 
     def _begin_episode(self, task_text: str) -> None:
-        """Start a new episode capture session.
-
-        :param task_text: Task description
-        """
         if self._episode:
-            log.warning("Episode already running; ending previous")
-            self._end_episode("replaced")
+            log.warning("Episode already running; ignoring new start.")
+            return
 
         episode_id = str(uuid.uuid4())[:8]
         tmpdir = tempfile.mkdtemp(prefix=f"episode-{episode_id}-")
-
         self._episode = EpisodeBuffer(
             root=tmpdir,
             episode_id=episode_id,
             task_text=task_text,
-            screen_size=self.neko.frame_size
+            screen_size=self.neko.frame_size,
         )
         self._episode_last_ts = time.time()
-
         log.info("Episode %s started: %s", episode_id, task_text)
 
-        # Start screenshot polling thread
         self._poll_stop_event = threading.Event()
         self._poll_thread = threading.Thread(
             target=self._screenshot_poller,
@@ -290,90 +290,143 @@ class NekoCapture:
         self._poll_thread.start()
 
     def _end_episode(self, reason: str) -> None:
-        """End the current episode capture session.
-
-        :param reason: Reason for ending
-        """
         if not self._episode:
             return
 
         episode = self._episode
         self._episode = None
 
-        # Stop screenshot polling
         if self._poll_thread and self._poll_stop_event:
             self._poll_stop_event.set()
             self._poll_thread.join(timeout=3.0)
-            self._poll_thread = None
-            self._poll_stop_event = None
+        self._poll_thread = None
+        self._poll_stop_event = None
 
-        # Check if episode meets minimum requirements
-        if episode.frame_count >= self.min_frames:
-            # Finalize and write episode
-            payload = episode.finalize_zip_bytes(self._agent_meta)
+        num_actions = self._count_ndjson(episode.actions_path)
+        ended_at = now_iso()
+        payload = episode.finalize_zip_bytes(ended_at=ended_at, agent_meta=self._agent_meta)
+        num_frames = self._frames_count_from_zip(payload)
 
+        if num_frames >= self.min_frames:
             sample = {
                 "episode_id": episode.episode_id,
                 "task": episode.task_text,
-                "frame_count": episode.frame_count,
-                "screen_size": episode.screen_size,
                 "payload": payload,
+                "num_frames": num_frames,
+                "num_actions": num_actions,
+                "started_at": episode.started_at,
+                "ended_at": ended_at,
+                "screen_w": episode.screen_size[0],
+                "screen_h": episode.screen_size[1],
+                "agent": self._agent_meta,
             }
-
             self.writer.write(sample)
-            log.info("Episode %s completed (%d frames, %s)",
-                    episode.episode_id, episode.frame_count, reason)
+            log.info(
+                "Episode %s committed (%d frames, %d actions) [%s]",
+                episode.episode_id,
+                num_frames,
+                num_actions,
+                reason,
+            )
         else:
-            log.info("Episode %s discarded (only %d frames, minimum %d)",
-                    episode.episode_id, episode.frame_count, self.min_frames)
-
-        # Clean up temporary directory
-        try:
-            shutil.rmtree(episode.root)
-        except Exception as e:
-            log.warning("Failed to clean up episode dir: %s", e)
+            log.warning(
+                "Episode %s discarded (too short: %d frames) [%s]",
+                episode.episode_id,
+                num_frames,
+                reason,
+            )
 
     def _screenshot_poller(self, stop_event: threading.Event) -> None:
-        """Background thread that polls screenshots at fixed FPS."""
         interval = 1.0 / self.fps
-
-        while not stop_event.is_set() and self._episode:
+        while not stop_event.is_set():
             start_time = time.time()
+            episode = self._episode
+            if not episode:
+                break
 
-            # Get screenshot
             img = self.neko.get_screenshot(self.jpeg_quality)
             if img and self._episode:
-                self._episode.add_frame(img, self.jpeg_quality)
-                self._episode_last_ts = time.time()
+                with io.BytesIO() as buffer:
+                    img.save(buffer, "JPEG", quality=self.jpeg_quality)
+                    frame_bytes = buffer.getvalue()
+                if hasattr(img, "close"):
+                    img.close()
+                ts = time.time()
+                self._episode.add_frame(frame_bytes, ts)
+                self._episode_last_ts = ts
 
-            # Sleep for remaining interval
             elapsed = time.time() - start_time
-            sleep_time = max(0, interval - elapsed)
+            sleep_time = max(0.0, interval - elapsed)
             if sleep_time > 0:
                 time.sleep(sleep_time)
 
     async def _cleanup(self) -> None:
-        """Clean up resources."""
         self._stop_event.set()
-
-        # End any active episode
         if self._episode:
             self._end_episode("shutdown")
 
         if self._poll_stop_event:
             self._poll_stop_event.set()
-            self._poll_stop_event = None
+        if self._poll_thread:
+            self._poll_thread.join(timeout=3.0)
+            self._poll_thread = None
+        self._poll_stop_event = None
 
-        # Disconnect from Neko
+        with contextlib.suppress(Exception):
+            self.neko.stop()
         await self.neko.disconnect()
 
-        # Close writer
-        self.writer.finish()
+        try:
+            self.writer.finish()
+        except Exception:
+            pass
+
         log.info("Capture session ended")
 
+    @staticmethod
+    def _count_ndjson(path: str) -> int:
+        if not os.path.exists(path):
+            return 0
+        count = 0
+        with open(path, "rb") as fh:
+            for _ in fh:
+                count += 1
+        return count
 
-async def main():
-    """Main entry point."""
+    @staticmethod
+    def _frames_count_from_zip(zip_bytes: bytes) -> int:
+        try:
+            with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
+                return len([n for n in zf.namelist() if n.startswith("frames/") and n.endswith(".jpg")])
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _extract_text(msg: Dict[str, Any]) -> Optional[str]:
+        event = msg.get("event", "")
+        payload = msg.get("payload", {})
+
+        if event == "chat/message":
+            content = payload.get("content")
+            if isinstance(content, dict):
+                text = content.get("text")
+                if isinstance(text, str):
+                    return text
+            text = payload.get("text") or payload.get("message")
+            if isinstance(text, str):
+                return text
+        elif event in ("send/broadcast", "send/unicast"):
+            body = payload.get("body")
+            if isinstance(body, str):
+                return body
+            if isinstance(body, dict):
+                text = body.get("text") or body.get("message")
+                if isinstance(text, str):
+                    return text
+        return None
+
+
+async def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Neko training data capture")
@@ -386,57 +439,43 @@ async def main():
 
     args = parser.parse_args()
 
-    # Set up logging
     logging.basicConfig(
         level=logging.INFO,
         format='[%(asctime)s] %(name)-12s %(levelname)-7s - %(message)s',
         datefmt='%H:%M:%S'
     )
 
-    # Create Neko client
     neko_client = HTTPNekoClient(
         base_url=args.neko_url or os.environ.get("NEKO_URL"),
         ws_url=args.ws or os.environ.get("NEKO_WS"),
         username=args.username or os.environ.get("NEKO_USER"),
-        password=args.password or os.environ.get("NEKO_PASS")
+        password=args.password or os.environ.get("NEKO_PASS"),
     )
 
-    # Create MDS writer
-    columns = {
-        "episode_id": "str",
-        "task": "str",
-        "frame_count": "int",
-        "screen_size": "json",
-        "payload": "bytes",
-    }
-
-    writer = MDSWriter(
-        out=args.output,
-        columns=columns,
+    writer = make_mds_writer(
+        local_out=args.output,
+        remote_out=(args.remote or None) or (CAPTURE_REMOTE or None),
+        keep_local=CAPTURE_KEEP_LOCAL,
         compression=CAPTURE_COMPRESSION,
+        shard_size=CAPTURE_SHARD_SIZE,
         hashes=CAPTURE_HASHES,
-        size_limit=CAPTURE_SHARD_SIZE,
     )
 
-    if args.remote:
-        writer = MDSWriter(
-            out=args.remote,
-            columns=columns,
-            compression=CAPTURE_COMPRESSION,
-            hashes=CAPTURE_HASHES,
-            size_limit=CAPTURE_SHARD_SIZE,
-            keep_local=bool(CAPTURE_KEEP_LOCAL),
-        )
-
-    # Create and run capture
-    capture = NekoCapture(neko_client, writer)
+    capture = NekoCapture(
+        neko_client,
+        writer,
+        fps=CAPTURE_FPS,
+        jpeg_quality=CAPTURE_JPEG_QUALITY,
+        min_frames=CAPTURE_MIN_FRAMES,
+        episode_timeout=CAPTURE_EP_TIMEOUT,
+    )
 
     try:
         await capture.run()
     except KeyboardInterrupt:
         log.info("Interrupted by user")
-    except Exception as e:
-        log.error("Capture failed: %s", e, exc_info=True)
+    except Exception as exc:
+        log.error("Capture failed: %s", exc, exc_info=True)
 
 
 if __name__ == "__main__":

--- a/src/manual_refactored.py
+++ b/src/manual_refactored.py
@@ -15,11 +15,12 @@ Refactored from original manual.py to use modular neko_comms library.
 """
 
 import asyncio
+import json
 import logging
 import os
 import shlex
 import sys
-from typing import Dict, Any, Tuple, Optional
+from typing import Dict, Any, Tuple, Optional, List
 
 import requests
 
@@ -57,7 +58,8 @@ class ManualController:
     """Interactive manual control interface using WebRTCNekoClient."""
 
     def __init__(self, ws_url: str, width: int = 1920, height: int = 1080,
-                 normalized: bool = False, auto_host: bool = True):
+                 normalized: bool = False, auto_host: bool = True,
+                 base_url: Optional[str] = None, token: Optional[str] = None):
         """Initialize the manual controller.
 
         :param ws_url: WebSocket URL for Neko connection
@@ -65,12 +67,16 @@ class ManualController:
         :param height: Virtual screen height
         :param normalized: If True, coordinates are 0-1 and scaled
         :param auto_host: If True, automatically request host control
+        :param base_url: REST base URL (when available) for admin commands
+        :param token: REST API bearer token for admin commands
         """
         self.ws_url = ws_url
         self.width = width
         self.height = height
         self.normalized = normalized
         self.auto_host = auto_host
+        self.base_url = base_url.rstrip("/") if base_url else None
+        self.token = token
 
         # State
         self.running = True
@@ -193,17 +199,50 @@ class ManualController:
             elif cmd == "swipe":
                 await self._handle_swipe(args)
 
+            elif cmd == "raw":
+                await self._handle_raw(args)
+
             elif cmd == "key":
                 await self._handle_key(args)
+
+            elif cmd == "enter":
+                await self._handle_enter()
+
+            elif cmd == "text":
+                await self._handle_type(args)
+
+            elif cmd == "input":
+                await self._handle_input(args)
 
             elif cmd == "type":
                 await self._handle_type(args)
 
+            elif cmd in ("copy", "cut", "select_all"):
+                await self._handle_clipboard(cmd)
+
+            elif cmd == "paste":
+                await self._handle_paste(args)
+
             elif cmd == "host":
                 await self.client.request_host_control()
 
+            elif cmd == "unhost":
+                await self.client.release_host_control()
+
             elif cmd == "size":
                 await self._handle_size(args)
+
+            elif cmd == "force-take":
+                await self._handle_force(True)
+
+            elif cmd == "force-release":
+                await self._handle_force(False)
+
+            elif cmd == "kick":
+                await self._handle_kick(args)
+
+            elif cmd == "sessions":
+                await self._handle_sessions()
 
             else:
                 print(f"Unknown command: {cmd}. Type 'help' for available commands.")
@@ -211,6 +250,18 @@ class ManualController:
         except Exception as e:
             logger.error("Command error: %s", e)
             print(f"Error: {e}")
+
+    async def _safe_send(self, event: str, payload: Optional[Dict[str, Any]] = None) -> None:
+        """Send an event if the client is connected."""
+        if not self.client.is_connected():
+            print("Not connected to server")
+            return
+
+        try:
+            await self.client.send_event(event, payload)
+        except Exception as exc:
+            logger.error("Failed to send event %s: %s", event, exc)
+            print(f"Error sending event: {exc}")
 
     def _show_help(self) -> None:
         """Show help text."""
@@ -220,31 +271,56 @@ Available commands:
 Movement & Clicking:
   move X Y                - Move cursor to coordinates
   click [X Y] [button]    - Click at coordinates (or current position)
-  rclick [X Y]           - Right-click at coordinates
-  lclick [X Y]           - Left-click at coordinates
-  dblclick [X Y]         - Double-click at coordinates
-  tap X Y                - Touch/tap at coordinates
-  hover X Y              - Hover at coordinates
+  rclick | lclick         - Right or left click aliases
+  dblclick [X Y]          - Double-click at coordinates
+  tap X Y [button]        - Move and click at coordinates
+  hover X Y               - Hover cursor at coordinates
+  swipe X1 Y1 X2 Y2       - Drag from point 1 to point 2
 
-Scrolling & Gestures:
-  scroll up|down|left|right [amount]  - Scroll in direction
-  swipe X1 Y1 X2 Y2      - Swipe from point 1 to point 2
+Keyboard & Text:
+  key <keyname>           - Press a key (Escape, F5, etc.)
+  enter                   - Press the Enter/Return key
+  type <text>             - Type text at current focus
+  text <text>             - Alias for type
+  input X Y "text"        - Click at X,Y then type text
+  copy | cut | select_all - Clipboard shortcuts
+  paste [text]            - Paste clipboard or provided text
 
-Keyboard:
-  key <keyname>          - Press a key (e.g., "Enter", "Escape", "F1")
-  type <text>            - Type text string
+Raw / Admin:
+  raw '{"event":...}'    - Send raw JSON event
+  host / unhost           - Request or release host control
+  force-take              - Force host control (admin)
+  force-release           - Force release host control (admin)
+  kick <sessionId>        - Kick a session (admin)
+  sessions                - List sessions (requires REST login)
 
-Control:
-  host                   - Request host control
-  size WIDTH HEIGHT      - Set screen dimensions
-  help                   - Show this help
-  quit / exit / q        - Exit program
+Other:
+  size [WIDTH HEIGHT]     - Show or set screen dimensions
+  scroll dir [amount]     - Scroll direction (up/down/left/right)
+  help                    - Show this help
+  quit / exit / q         - Exit program
 
 Coordinates:
-  - Use pixel coordinates (0,0 = top-left)
-  - Screen size: {width}x{height}
+  - Use pixel coordinates (0,0 = top-left) unless --normalized
+  - Current screen size: {width}x{height}
 """.format(width=self.width, height=self.height)
         print(help_text)
+
+    def _action_executor(self):
+        if not self.client.action_executor:
+            raise RuntimeError("Action executor not ready")
+        return self.client.action_executor
+
+    def _parse_text_argument(self, args: List[str], usage: str) -> Optional[str]:
+        """Join and normalize quoted text arguments."""
+        if not args:
+            print(usage)
+            return None
+
+        text = " ".join(args)
+        if len(text) >= 2 and text[0] == text[-1] and text[0] in ('"', "'"):
+            text = text[1:-1]
+        return text
 
     def _xy(self, x: float, y: float) -> Tuple[int, int]:
         """Convert input coordinates to pixel coordinates.
@@ -281,7 +357,7 @@ Coordinates:
             self._curx, self._cury = px, py
 
             # Send move command via action executor
-            await self.client.action_executor.move(px, py)
+            await self._action_executor().move(px, py)
             print(f"Moved to ({px}, {py})")
 
         except ValueError:
@@ -305,7 +381,7 @@ Coordinates:
                 x, y = float(args[0]), float(args[1])
                 px, py = self._xy(x, y)
                 self._curx, self._cury = px, py
-                await self.client.action_executor.move(px, py)
+                await self._action_executor().move(px, py)
             except ValueError:
                 print("Invalid coordinates")
                 return
@@ -316,12 +392,12 @@ Coordinates:
         if cmd == "hover":
             print(f"Hovering at ({px}, {py})")
         elif cmd == "dblclick":
-            await self.client.action_executor.button_press(px, py, button)
+            await self._action_executor().button_press(px, py, button)
             await asyncio.sleep(0.05)
-            await self.client.action_executor.button_press(px, py, button)
+            await self._action_executor().button_press(px, py, button)
             print(f"Double-clicked {button} at ({px}, {py})")
         else:
-            await self.client.action_executor.button_press(px, py, button)
+            await self._action_executor().button_press(px, py, button)
             print(f"Clicked {button} at ({px}, {py})")
 
     async def _handle_scroll(self, args: list) -> None:
@@ -331,7 +407,11 @@ Coordinates:
             return
 
         direction = args[0].lower()
-        amount = int(args[1]) if len(args) > 1 else 1
+        try:
+            amount = int(args[1]) if len(args) > 1 else 1
+        except ValueError:
+            print("Invalid scroll amount")
+            return
 
         # Map direction to scroll deltas
         delta_map = {
@@ -346,7 +426,7 @@ Coordinates:
             return
 
         dx, dy = delta_map[direction]
-        await self.client.action_executor.scroll(dx, dy)
+        await self._action_executor().scroll(dx, dy)
         print(f"Scrolled {direction} (amount: {amount})")
 
     async def _handle_swipe(self, args: list) -> None:
@@ -362,7 +442,7 @@ Coordinates:
             p1 = self._xy(x1, y1)
             p2 = self._xy(x2, y2)
 
-            await self.client.action_executor.swipe(p1[0], p1[1], p2[0], p2[1])
+            await self._action_executor().swipe(p1[0], p1[1], p2[0], p2[1])
             print(f"Swiped from {p1} to {p2}")
 
         except ValueError:
@@ -380,26 +460,174 @@ Coordinates:
             print(f"Unknown key: {key}")
             return
 
-        await self.client.action_executor.key_once(key)
+        await self._action_executor().key_once(key)
         print(f"Pressed key: {key}")
 
     async def _handle_type(self, args: list) -> None:
         """Handle type command."""
-        if not args:
-            print("Usage: type <text>")
+        text = self._parse_text_argument(args, "Usage: type <text>")
+        if text is None:
             return
 
-        text = " ".join(args)
-
-        # Remove surrounding quotes if present
-        if len(text) >= 2 and text[0] == text[-1] and text[0] in ('"', "'"):
-            text = text[1:-1]
-
-        await self.client.action_executor.type_text(text)
+        await self._action_executor().type_text(text)
         print(f"Typed: {text}")
+
+    async def _handle_enter(self) -> None:
+        """Handle enter command."""
+        await self._action_executor().key_once("Enter")
+        print("Pressed Enter")
+
+    async def _handle_input(self, args: List[str]) -> None:
+        """Handle input command to click and type text."""
+        if len(args) < 3:
+            print("Usage: input X Y \"text\"")
+            return
+
+        try:
+            x, y = float(args[0]), float(args[1])
+        except ValueError:
+            print("Invalid coordinates")
+            return
+
+        text = self._parse_text_argument(args[2:], "Usage: input X Y \"text\"")
+        if text is None:
+            return
+
+        px, py = self._xy(x, y)
+        await self._action_executor().move(px, py)
+        await self._action_executor().button_press(px, py, "left")
+        await asyncio.sleep(0.05)
+        await self._action_executor().type_text(text)
+        print(f"Clicked ({px}, {py}) and typed: {text}")
+
+    async def _handle_clipboard(self, cmd: str) -> None:
+        """Handle clipboard-related commands."""
+        executor = self._action_executor()
+
+        if cmd == "copy":
+            await executor.copy()
+            print("Copied selection")
+            return
+
+        if cmd == "cut":
+            await executor.key_down("Control")
+            await executor.key_once("x")
+            await executor.key_up("Control")
+            print("Cut selection")
+            return
+
+        if cmd == "select_all":
+            await executor.key_down("Control")
+            await executor.key_once("a")
+            await executor.key_up("Control")
+            print("Selected all")
+            return
+
+    async def _handle_paste(self, args: List[str]) -> None:
+        """Handle paste command."""
+        text = None
+        if args:
+            text = self._parse_text_argument(args, "Usage: paste [text]")
+            if text is None:
+                return
+
+        payload = {"text": text or ""}
+        await self._safe_send("control/paste", payload)
+        if text:
+            print(f"Pasted text: {text}")
+        else:
+            print("Requested paste from clipboard")
+
+    async def _handle_raw(self, args: List[str]) -> None:
+        """Send raw JSON message."""
+        if not args:
+            print("Usage: raw '{\"event\":..., \"payload\":{...}}'")
+            return
+
+        raw = " ".join(args)
+        try:
+            message = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print(f"Invalid JSON: {exc}")
+            return
+
+        if not isinstance(message, dict) or "event" not in message:
+            print("JSON must include 'event'")
+            return
+
+        event = message["event"]
+        payload = message.get("payload")
+        if payload is not None and not isinstance(payload, dict):
+            print("payload must be an object if provided")
+            return
+
+        await self._safe_send(event, payload)
+        print(f"Sent raw event: {event}")
+
+    async def _handle_force(self, take: bool) -> None:
+        """Handle force host commands."""
+        session_id = self.client.session_id
+        if not session_id:
+            print("Session ID unknown; wait for connection to stabilize")
+            return
+
+        event = "admin/control" if take else "admin/release"
+        await self._safe_send(event, {"id": session_id})
+        print(("Force-take" if take else "Force-release") + " sent")
+
+    async def _handle_kick(self, args: List[str]) -> None:
+        """Handle kick command."""
+        if not args:
+            print("Usage: kick <sessionId>")
+            return
+
+        target = args[0]
+        await self._safe_send("admin/kick", {"id": target})
+        print(f"Kick sent for session {target}")
+
+    async def _handle_sessions(self) -> None:
+        """List active sessions via REST API."""
+        if not self.base_url or not self.token:
+            print("Sessions command requires REST login (provide --neko-url credentials)")
+            return
+
+        url = f"{self.base_url}/api/sessions"
+        headers = {"Authorization": f"Bearer {self.token}"}
+
+        try:
+            response = await asyncio.to_thread(requests.get, url, headers=headers, timeout=10.0)
+            response.raise_for_status()
+        except Exception as exc:
+            logger.error("Failed to fetch sessions: %s", exc)
+            print(f"Error fetching sessions: {exc}")
+            return
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            print(f"Invalid JSON from sessions endpoint: {exc}")
+            return
+
+        if not data:
+            print("No active sessions")
+            return
+
+        if isinstance(data, list):
+            print("Sessions:")
+            for sess in data:
+                sid = sess.get("id") or sess.get("session_id")
+                user = sess.get("username") or sess.get("user", {}).get("username")
+                has_host = sess.get("has_host") or sess.get("host")
+                print(f"  - id={sid} user={user} host={has_host}")
+        else:
+            print(json.dumps(data, indent=2, ensure_ascii=False))
 
     async def _handle_size(self, args: list) -> None:
         """Handle size command."""
+        if not args:
+            print(f"Current size: {self.width}x{self.height} normalized={self.normalized}")
+            return
+
         if len(args) < 2:
             print("Usage: size WIDTH HEIGHT")
             return
@@ -407,15 +635,14 @@ Coordinates:
         try:
             width = int(args[0])
             height = int(args[1])
-
-            self.width = width
-            self.height = height
-            self.client.set_screen_size(width, height)
-
-            print(f"Screen size set to {width}x{height}")
-
         except ValueError:
             print("Invalid dimensions")
+            return
+
+        self.width = width
+        self.height = height
+        self.client.set_screen_size(width, height)
+        print(f"Screen size set to {width}x{height}")
 
 
 async def main():
@@ -434,12 +661,15 @@ async def main():
 
     args = parser.parse_args()
 
+    base_url = None
+    token = None
+
     # Determine WebSocket URL
     if args.ws:
         ws_url = args.ws
     elif args.neko_url and args.username and args.password:
         try:
-            ws_url, _, _ = rest_login_and_ws_url(args.neko_url, args.username, args.password)
+            ws_url, base_url, token = rest_login_and_ws_url(args.neko_url, args.username, args.password)
         except ValueError as e:
             print(f"Login failed: {e}")
             sys.exit(1)
@@ -454,7 +684,7 @@ async def main():
             pass  # Use direct WebSocket URL
         elif neko_url and username and password:
             try:
-                ws_url, _, _ = rest_login_and_ws_url(neko_url, username, password)
+                ws_url, base_url, token = rest_login_and_ws_url(neko_url, username, password)
             except ValueError as e:
                 print(f"Login failed: {e}")
                 sys.exit(1)
@@ -468,7 +698,9 @@ async def main():
         width=args.width,
         height=args.height,
         normalized=args.normalized,
-        auto_host=not args.no_auto_host
+        auto_host=not args.no_auto_host,
+        base_url=base_url,
+        token=token
     )
 
     await controller.run()

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -6,7 +6,8 @@ for monitoring Neko Agent operations across all components.
 
 import logging
 from typing import Any, Tuple
-from prometheus_client import start_http_server, Counter, Histogram
+
+from prometheus_client import Counter, Histogram, start_http_server
 
 # Metrics definitions
 frames_received = Counter("neko_frames_received_total", "Total video frames received")
@@ -22,9 +23,10 @@ def start_metrics_server(port: int, logger: logging.Logger) -> Tuple[Any, Any]:
     """Start Prometheus metrics server.
 
     :param port: Port number to bind the metrics server to
-    :param logger: Logger instance for recording server startup status
-    :return: Tuple of (server, thread) for clean shutdown
+    :param logger: Logger for status reporting
+    :return: Tuple of (server, thread) handles when available
     """
+
     try:
         ret = start_http_server(port)
         if isinstance(ret, tuple) and len(ret) == 2:
@@ -33,6 +35,6 @@ def start_metrics_server(port: int, logger: logging.Logger) -> Tuple[Any, Any]:
             server, thread = ret, None
         logger.info("Metrics server started on port %d", port)
         return server, thread
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - defensive logging
         logger.error("Failed to start metrics server on port %d: %s", port, e)
         return None, None

--- a/src/neko_comms/actions.py
+++ b/src/neko_comms/actions.py
@@ -13,6 +13,9 @@ from typing import Callable, Tuple, List, Optional, Dict, Any
 
 from .types import Action, BUTTON_CODES, name_keysym, clamp_xy, ACTION_SPACES
 
+
+COMPLETION_ACTIONS = {"DONE"}
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,7 +48,10 @@ def safe_parse_action(output_text: str, nav_mode: str = "web", logger: Optional[
     try:
         assert isinstance(act, dict)
         typ = act.get("action")
-        if typ not in ACTION_SPACES.get(nav_mode, []):
+        if typ in COMPLETION_ACTIONS:
+            act.setdefault("value", None)
+            act.setdefault("position", None)
+        elif typ not in ACTION_SPACES.get(nav_mode, []):
             if logger:
                 logger.warning("Non-whitelisted action: %r", typ)
             if parse_errors_counter:

--- a/src/neko_comms/webrtc_client.py
+++ b/src/neko_comms/webrtc_client.py
@@ -44,7 +44,7 @@ class WebRTCNekoClient(NekoClient):
     Supports both inbound video and outbound audio tracks.
     """
 
-    def __init__(self, ws_url: str, ice_servers: Optional[List[str]] = None, **kwargs):
+    def __init__(self, ws_url: str, ice_servers: Optional[List[Any]] = None, **kwargs):
         """Initialize the WebRTC Neko client.
 
         :param ws_url: WebSocket URL for signaling
@@ -227,7 +227,12 @@ class WebRTCNekoClient(NekoClient):
 
     async def _setup_peer_connection(self) -> None:
         """Initialize the WebRTC peer connection with ICE servers."""
-        ice_servers = [RTCIceServer(urls=url) for url in self.ice_servers]
+        ice_servers: List[RTCIceServer] = []
+        for entry in self.ice_servers:
+            if isinstance(entry, dict):
+                ice_servers.append(RTCIceServer(**entry))
+            else:
+                ice_servers.append(RTCIceServer(urls=entry))
         config = RTCConfiguration(iceServers=ice_servers)
 
         if self.ice_policy == "strict":


### PR DESCRIPTION
## Summary
- parse NEKO_AUDIO and inference timeout settings robustly while reusing the action-space description in the refactored agent
- restore iterative click refinement with cancellation-aware inference and DONE completion support
- expose chat listeners on the HTTP client and rework capture_refactored to use them with its own poll-stop event and timestamp refresh

## Testing
- ruff check . *(fails: repository already contains numerous lint issues in src/yap.py and src/yap_refactored.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d243176c588331950a0ce59167c550